### PR TITLE
reset current time picker only if having multiple time picker

### DIFF
--- a/js/timepicki.js
+++ b/js/timepicki.js
@@ -77,7 +77,7 @@
 			var inputs = ele_par.find('input');
 			
 			$('.reset_time').on("click", function(event) {
-				ele.val("");
+				$(this).parents('.time_pick').find('.text').val("");
 				close_timepicki();
 			});		
 			$(".timepicki-input").keydown( function(keyevent){


### PR DESCRIPTION
# Time picker reset issue

> if you have multiple time picker in your window with same class name (you have used to reduce overhead to set time picker again and again for different text field) then when you click on reset it resets all time picker value

> current PR reset the value of current parent only .
