### PR TITLE
Update timepicki.js

### DIFF
--- a/js/timepicki.js
+++ b/js/timepicki.js
@@ -405,9 +405,15 @@
 					ti = d.getHours();
 					mi = d.getMinutes();
 					mer = "AM";
-					if (12 < ti  && settings.show_meridian) {
-						ti -= 12;
-						mer = "PM";
+					if (settings.show_meridian){
+						if (ti == 0) { // midnight 
+							ti = 12;
+						} else if (ti == 12) { // noon
+							mer = "PM";
+						} else if (ti > 12) {
+							ti -= 12;
+							mer = "PM";
+						}
 					}
 				}
 


### PR DESCRIPTION
While displaying meridian the default time loads incorrectly for midnight and noon.

It displays 00 during the midnight hour, which should display 12
It shows "AM" during the noon hour, which should display "PM"