### PR TITLE
Update timepicki.js

### DIFF
--- a/js/timepicki.js
+++ b/js/timepicki.js
@@ -34,7 +34,7 @@
 			        if (mini < 10)
 			            mini = "0" + mini;
 
-			        mini = Math.min(Math.max(parseInt(mini), 0), 59);
+			        //mini = Math.min(Math.max(parseInt(mini), 0), 59);
 
 					return tim + ":" + mini;
 				}


### PR DESCRIPTION
Line 37 breaks display option when minutes between 0 and 9 (will show 15:8 instead of 15:08)
