### PR TITLE
Adding snapToStep option and fixing syntax warnings.

### DIFF
--- a/css/timepicki.css
+++ b/css/timepicki.css
@@ -75,6 +75,32 @@ Author: senthil
 	height: 10px;
 	z-index: 999;
 }
+.timepicker_wrap .timepicki-close-container {
+	text-align: right;
+	display: block;
+	width: 100%;
+	clear: both;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+.timepicker_wrap .timepicki-close {
+	float: right;
+	font-size: 25px;
+	color: #999;
+	clear: both;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	padding-left: 10px;
+	padding-right: 5px;
+	display: inline-block;
+	margin-right: -5px;
+	line-height: 1;
+	padding-bottom: 10px;
+}
 input.timepicki-input {
 	background: none repeat scroll 0 0 #FFFFFF;
     	border: 1px solid #CCCCCC;

--- a/options.html
+++ b/options.html
@@ -85,6 +85,18 @@
 		<input id="timepicker5" type="text" name="timepicker5"/>
 	    </div>
 		<div class="text-left">
+		<h3>Snap to Step</h3>
+		<p>If true, setting the time will snap it to the closest "step" (based on step_size_hours and step_size_minutes values).</p>
+		<pre>&lt;script type='text/javascript'&gt;
+	$('#timepicker6a').timepicki({
+		snapToStep: true,
+		step_size_hours:2,
+		step_size_minutes:15});
+&lt;/script&gt;</pre>
+		<input id="timepicker6a" type="text" name="timepicker6a"/>
+		<p>here the minutes are changed per quarter instead of per minute, and the hours will be changed per two.</p>
+	    </div>
+		<div class="text-left">
 		<h3>Set step size hour and minutes</h3>
 		<p>with this option you can choose the step size with which minutes and hours have to increase or decrease.</p>
 		<pre>&lt;script type='text/javascript'&gt;
@@ -173,6 +185,10 @@
 	$('#timepicker3').timepicki({max_hour_value:8}); 
 	$('#timepicker4').timepicki({custom_classes:"myclass"});
 	$('#timepicker5').timepicki({show_meridian:false});
+	$('#timepicker6a').timepicki({
+		snapToStep:true,
+		step_size_hours:2,
+		step_size_minutes:15});
 	$('#timepicker6').timepicki({
 		step_size_hours:2,
 		step_size_minutes:15});


### PR DESCRIPTION
Hello,
I've added a new option (called snapToStep), where the hours and minutes selectors will snap to the closest "step". That is, if setting step_size_minutes:15, Timepicki will set the minutes field to the closest 15-minute step. For instance, if current time is 09:45, the picker will be set to 09:**45**.

I've also fixed a couple of warnings thrown by the debugger and updated the docs to include the snapToStep option.