### PR TITLE
Remove whitespace between number and colon in 24hr

### DIFF
--- a/js/timepicki.js
+++ b/js/timepicki.js
@@ -36,7 +36,7 @@
 
 			        //mini = Math.min(Math.max(parseInt(mini), 0), 59);
 
-					return tim + ":" + mini;
+					return (tim + ":" + mini).replace(/ /g,'');
 				}
 			},
 			increase_direction: 'up',


### PR DESCRIPTION
The whitespaces causes some issues in parsing the time in most cases.